### PR TITLE
fix: 계좌 목록 모바일 margin 안 먹는 현상 수정

### DIFF
--- a/src/pages/style.scss
+++ b/src/pages/style.scss
@@ -1,5 +1,8 @@
 @import '~swiper/swiper-bundle.css';
-
+:root {
+    --swiper-navigation-size: 0px;
+  }
+  
 .header {
   display: flex;
   align-items: center;
@@ -249,3 +252,4 @@
     }
   }
 }
+


### PR DESCRIPTION
## 개요
- 계좌 목록 모바일 margin 안 먹는 현상 수정

## 작업사항
-     --swiper-navigation-size: 0px; 부여

## 참고자료
<!-- 참고자료 등 기타 내용 작성 -->
